### PR TITLE
Fix collision detection and test package

### DIFF
--- a/app/src/androidTest/java/com/example/trickytower/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/example/trickytower/ExampleInstrumentedTest.java
@@ -21,6 +21,6 @@ public class ExampleInstrumentedTest {
     public void useAppContext() {
         // Context of the app under test.
         Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
-        assertEquals("kr.ac.tukorea.ge.scgyong.cookierun", appContext.getPackageName());
+        assertEquals("com.example.trickytower", appContext.getPackageName());
     }
 }

--- a/app/src/main/java/com/example/trickytower/util/BlockCollisionHelper.java
+++ b/app/src/main/java/com/example/trickytower/util/BlockCollisionHelper.java
@@ -28,15 +28,17 @@ public class BlockCollisionHelper {
             return Metrics.height;
         }
         // 2) 쌓인 블록들과 충돌 검사
+        float closestY = Float.NaN;
         for (IBoxCollidable landed : landedBlocks) {
             RectF lr = landed.getCollisionRect();
             float cx = rect.centerX();
             if (cx >= lr.left && cx <= lr.right && bottom >= lr.top) {
-                return lr.top;
+                if (Float.isNaN(closestY) || lr.top > closestY) {
+                    closestY = lr.top;
+                }
             }
         }
-        // 충돌 없음
-        return Float.NaN;
+        return closestY;
     }
 
     /**


### PR DESCRIPTION
## Summary
- correct package name in ExampleInstrumentedTest
- handle stacked-block collisions correctly

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684c66b6bff083279ebda67ffb53b91c