### PR TITLE
Implement basic scoring

### DIFF
--- a/app/src/main/java/com/example/trickytower/objects/ScoreLabel.java
+++ b/app/src/main/java/com/example/trickytower/objects/ScoreLabel.java
@@ -1,0 +1,45 @@
+package com.example.trickytower.objects;
+
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.Typeface;
+
+import kr.ac.tukorea.ge.spgp2025.a2dg.framework.interfaces.IGameObject;
+
+/**
+ * Simple text-based score display.
+ */
+public class ScoreLabel implements IGameObject {
+    private final Paint paint = new Paint();
+    private final float x;
+    private final float y;
+    private int score;
+
+    public ScoreLabel(float x, float y, float textSize) {
+        this.x = x;
+        this.y = y;
+        paint.setColor(Color.WHITE);
+        paint.setTextSize(textSize);
+        paint.setTypeface(Typeface.DEFAULT_BOLD);
+    }
+
+    /** Increase the score by the given amount. */
+    public void add(int amount) {
+        score += amount;
+    }
+
+    public int getScore() {
+        return score;
+    }
+
+    @Override
+    public void update() {
+        // nothing to update
+    }
+
+    @Override
+    public void draw(Canvas canvas) {
+        canvas.drawText("Score: " + score, x, y, paint);
+    }
+}

--- a/app/src/main/java/com/example/trickytower/scene/GameScene.java
+++ b/app/src/main/java/com/example/trickytower/scene/GameScene.java
@@ -10,6 +10,7 @@ import java.util.Random;
 import com.example.trickytower.R;
 import com.example.trickytower.objects.ComplexBlock;
 import com.example.trickytower.objects.ShapeType;
+import com.example.trickytower.objects.ScoreLabel;
 import com.example.trickytower.util.BlockCollisionHelper;
 
 import org.jbox2d.common.Vec2;
@@ -39,6 +40,8 @@ public class GameScene extends Scene {
     private final List<ComplexBlock> landedBlocks = new ArrayList<>();
     private final Random rand = new Random();
 
+    private ScoreLabel scoreLabel;
+
     private boolean touchEnabled;
     private boolean isFastDropping;
     private float touchStartX, touchStartY;
@@ -57,6 +60,8 @@ public class GameScene extends Scene {
             Metrics.width/2f, Metrics.height/2f,
             Metrics.width, Metrics.height
         ));
+        scoreLabel = new ScoreLabel(80f, 100f, 60f);
+        add(SceneLayer.UI, scoreLabel);
         spawnBlock();
     }
 
@@ -105,6 +110,7 @@ public class GameScene extends Scene {
                 body.setType(BodyType.STATIC);
                 body.setTransform(new Vec2(pos.x, centerYPixel/PPM), body.getAngle());
                 landedBlocks.add(current);
+                if (scoreLabel != null) scoreLabel.add(1);
                 spawnBlock();
             }
         }


### PR DESCRIPTION
## Summary
- add a `ScoreLabel` object for displaying text score
- show score in `GameScene` and increment when a block lands

## Testing
- `./gradlew test` *(fails: HTTP 403 - unable to download)*

------
https://chatgpt.com/codex/tasks/task_e_684c695cf5f48327a73acceadfd9c0f4